### PR TITLE
Use copy headers phase to avoid apple issue TN3110

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00E86D7417415AA000F0FA0A /* SVGKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E86D7317415AA000F0FA0A /* SVGKit.m */; };
-		036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		036A524D16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */; };
 		321EAA6A2171ECDE00640504 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 321EAA542171E72900640504 /* libxml2.tbd */; };
 		321EAA6B2171ECE200640504 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 321EAA582171E73800640504 /* Foundation.framework */; };
@@ -240,7 +240,7 @@
 		321EAB692172029800640504 /* SVGKFastImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863931688C2780059C9C4 /* SVGKFastImageView.m */; };
 		321EAB6A2172029800640504 /* SVGKImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863951688C2780059C9C4 /* SVGKImageView.m */; };
 		321EAB6B2172029800640504 /* SVGKLayeredImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863971688C2780059C9C4 /* SVGKLayeredImageView.m */; };
-		322A5B7D218BF990003D9CF1 /* SVGKInlineResource.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A5B7B218BF990003D9CF1 /* SVGKInlineResource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		322A5B7D218BF990003D9CF1 /* SVGKInlineResource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 322A5B7B218BF990003D9CF1 /* SVGKInlineResource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		322A5B7E218BF990003D9CF1 /* SVGKInlineResource.m in Sources */ = {isa = PBXBuildFile; fileRef = 322A5B7C218BF990003D9CF1 /* SVGKInlineResource.m */; };
 		322A5B80218BFE0F003D9CF1 /* SVGKInlineResource.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A5B7B218BF990003D9CF1 /* SVGKInlineResource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		322A5B81218BFE10003D9CF1 /* SVGKInlineResource.h in Headers */ = {isa = PBXBuildFile; fileRef = 322A5B7B218BF990003D9CF1 /* SVGKInlineResource.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -254,7 +254,7 @@
 		327B2897217DAC77004D27FC /* SVGRadialGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5DE2176E01400ED20D8 /* SVGRadialGradientElement.m */; };
 		32A1F09F21746F4700ABFCE1 /* SVGKitFramework_OSXTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32A1F09E21746F4700ABFCE1 /* SVGKitFramework_OSXTests.m */; };
 		32A1F0A121746F4700ABFCE1 /* SVGKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 321EAA622171EC8700640504 /* SVGKit.framework */; };
-		32C4891E21916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C4891E21916F3D007B1F29 /* SVGTextLayer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32C4891F21916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32C4892021916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32C4892121916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -265,242 +265,240 @@
 		32D3D5D72176E00E00ED20D8 /* SVGLinearGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5D52176E00D00ED20D8 /* SVGLinearGradientElement.m */; };
 		32D3D5D82176E00E00ED20D8 /* SVGLinearGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5D52176E00D00ED20D8 /* SVGLinearGradientElement.m */; };
 		32D3D5D92176E00E00ED20D8 /* SVGLinearGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5D52176E00D00ED20D8 /* SVGLinearGradientElement.m */; };
-		32D3D5DA2176E00E00ED20D8 /* SVGLinearGradientElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D3D5D62176E00D00ED20D8 /* SVGLinearGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D3D5DA2176E00E00ED20D8 /* SVGLinearGradientElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 32D3D5D62176E00D00ED20D8 /* SVGLinearGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D3D5DB2176E00E00ED20D8 /* SVGLinearGradientElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D3D5D62176E00D00ED20D8 /* SVGLinearGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D3D5DC2176E00E00ED20D8 /* SVGLinearGradientElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D3D5D62176E00D00ED20D8 /* SVGLinearGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D3D5DF2176E01400ED20D8 /* SVGRadialGradientElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D3D5DD2176E01400ED20D8 /* SVGRadialGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D3D5DF2176E01400ED20D8 /* SVGRadialGradientElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 32D3D5DD2176E01400ED20D8 /* SVGRadialGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D3D5E02176E01400ED20D8 /* SVGRadialGradientElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D3D5DD2176E01400ED20D8 /* SVGRadialGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D3D5E12176E01400ED20D8 /* SVGRadialGradientElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D3D5DD2176E01400ED20D8 /* SVGRadialGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D3D5E22176E01400ED20D8 /* SVGRadialGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5DE2176E01400ED20D8 /* SVGRadialGradientElement.m */; };
 		32D3D5E32176E01400ED20D8 /* SVGRadialGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5DE2176E01400ED20D8 /* SVGRadialGradientElement.m */; };
 		32D3D5E42176E01400ED20D8 /* SVGRadialGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5DE2176E01400ED20D8 /* SVGRadialGradientElement.m */; };
-		32EE37972173441400A23278 /* SVGKDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32EE37962173441400A23278 /* SVGKDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32EE37972173441400A23278 /* SVGKDefine.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 32EE37962173441400A23278 /* SVGKDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32EE37982173441400A23278 /* SVGKDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32EE37962173441400A23278 /* SVGKDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32EE37992173441400A23278 /* SVGKDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32EE37962173441400A23278 /* SVGKDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32EE379A2173441400A23278 /* SVGKDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32EE37962173441400A23278 /* SVGKDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32F206DB217324BB00427F24 /* SVGKExporterNSImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 32F206D9217324BB00427F24 /* SVGKExporterNSImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32F206DC217324BB00427F24 /* SVGKExporterNSImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F206DA217324BB00427F24 /* SVGKExporterNSImage.m */; };
-		4FD821F01AC69F6600E419D3 /* SVGSwitchElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FD821EE1AC69F6600E419D3 /* SVGSwitchElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FD821F01AC69F6600E419D3 /* SVGSwitchElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4FD821EE1AC69F6600E419D3 /* SVGSwitchElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FD821F11AC69F6600E419D3 /* SVGSwitchElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FD821EF1AC69F6600E419D3 /* SVGSwitchElement.m */; };
 		55452BF719EC68A200B75A30 /* libSVGKit-iOS.2.1.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639618E16145D0400E58CCA /* libSVGKit-iOS.2.1.0.a */; };
 		55452C0E19EC6EC600B75A30 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639633F16145DDC00E58CCA /* libxml2.dylib */; };
-		582A6AF8283AEBA20057FEAF /* SVGKit-iOS-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 582A6AF7283AEBA20057FEAF /* SVGKit-iOS-Prefix.pch */; };
-		582A6AFB283AEEA60057FEAF /* NamespacedDependencies.h in Headers */ = {isa = PBXBuildFile; fileRef = 582A6AFA283AEEA60057FEAF /* NamespacedDependencies.h */; };
 		660D50021C4292DB004187D0 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 660D4FF01C42927A004187D0 /* CocoaLumberjack.framework */; };
-		661ADBF216CC2FBE006F4BC3 /* SVGTextPositioningElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		661ADBF216CC2FBE006F4BC3 /* SVGTextPositioningElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		661ADBF316CC2FBE006F4BC3 /* SVGTextPositioningElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 661ADBF116CC2FBE006F4BC3 /* SVGTextPositioningElement.m */; };
-		661ADBF716CC2FCA006F4BC3 /* SVGTextContentElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		661ADBF716CC2FCA006F4BC3 /* SVGTextContentElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		661ADBF816CC2FCA006F4BC3 /* SVGTextContentElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 661ADBF616CC2FCA006F4BC3 /* SVGTextContentElement.m */; };
-		661ADBFC16CC364F006F4BC3 /* SVGTextPositioningElement_Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBFB16CC364F006F4BC3 /* SVGTextPositioningElement_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		661AE44916D13DA8005E69D9 /* SVGTransformable.h in Headers */ = {isa = PBXBuildFile; fileRef = 663FD01716CAF05900CCBFB3 /* SVGTransformable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		661AE44A16D13DAD005E69D9 /* SVGFitToViewBox.h in Headers */ = {isa = PBXBuildFile; fileRef = 66A09CB016CFF494003CD5CD /* SVGFitToViewBox.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		663403A4188EFC8A0077005F /* CALayer+RecursiveClone.h in Headers */ = {isa = PBXBuildFile; fileRef = 6636CD88175F54680072AAEF /* CALayer+RecursiveClone.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		661ADBFC16CC364F006F4BC3 /* SVGTextPositioningElement_Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 661ADBFB16CC364F006F4BC3 /* SVGTextPositioningElement_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		661AE44916D13DA8005E69D9 /* SVGTransformable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 663FD01716CAF05900CCBFB3 /* SVGTransformable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		661AE44A16D13DAD005E69D9 /* SVGFitToViewBox.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66A09CB016CFF494003CD5CD /* SVGFitToViewBox.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		663403A4188EFC8A0077005F /* CALayer+RecursiveClone.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6636CD88175F54680072AAEF /* CALayer+RecursiveClone.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6636CD7F175F542A0072AAEF /* SVGKSourceLocalFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 6636CD79175F542A0072AAEF /* SVGKSourceLocalFile.m */; };
 		6636CD81175F542A0072AAEF /* SVGKSourceString.m in Sources */ = {isa = PBXBuildFile; fileRef = 6636CD7B175F542A0072AAEF /* SVGKSourceString.m */; };
 		6636CD83175F542A0072AAEF /* SVGKSourceURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 6636CD7D175F542A0072AAEF /* SVGKSourceURL.m */; };
 		6636CD8B175F54680072AAEF /* CALayer+RecursiveClone.m in Sources */ = {isa = PBXBuildFile; fileRef = 6636CD89175F54680072AAEF /* CALayer+RecursiveClone.m */; };
-		6636CD8D175F54970072AAEF /* ConverterSVGToCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6636CD8C175F54970072AAEF /* ConverterSVGToCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66372EEE1695F16A008C6C56 /* DocumentCSS.h in Headers */ = {isa = PBXBuildFile; fileRef = 666674BD168A536C00486B68 /* DocumentCSS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66372EEF1695F17F008C6C56 /* DocumentStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 666674BE168A551300486B68 /* DocumentStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66372EF01695F193008C6C56 /* SVGStylable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DAF1689FF5D00EC93C7 /* SVGStylable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6636CD8D175F54970072AAEF /* ConverterSVGToCALayer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6636CD8C175F54970072AAEF /* ConverterSVGToCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66372EEE1695F16A008C6C56 /* DocumentCSS.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 666674BD168A536C00486B68 /* DocumentCSS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66372EEF1695F17F008C6C56 /* DocumentStyle.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 666674BE168A551300486B68 /* DocumentStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66372EF01695F193008C6C56 /* SVGStylable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DAF1689FF5D00EC93C7 /* SVGStylable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66372F5A16960D4F008C6C56 /* SVGRect.m in Sources */ = {isa = PBXBuildFile; fileRef = 66372F5916960D4E008C6C56 /* SVGRect.m */; };
 		6639619216145D0400E58CCA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639619116145D0400E58CCA /* Foundation.framework */; };
 		6639634216148CDF00E58CCA /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639634116148CDF00E58CCA /* QuartzCore.framework */; };
 		6639634716148DEC00E58CCA /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639634616148DEC00E58CCA /* CoreGraphics.framework */; };
-		663FD01416CAEF0D00CCBFB3 /* SVGHelperUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 663FD01216CAEF0B00CCBFB3 /* SVGHelperUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		663FD01416CAEF0D00CCBFB3 /* SVGHelperUtilities.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 663FD01216CAEF0B00CCBFB3 /* SVGHelperUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		663FD01516CAEF0D00CCBFB3 /* SVGHelperUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 663FD01316CAEF0C00CCBFB3 /* SVGHelperUtilities.m */; };
-		663FD01B16CBEF5E00CCBFB3 /* BaseClassForAllSVGBasicShapes_ForSubclasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 663FD01A16CBEF5C00CCBFB3 /* BaseClassForAllSVGBasicShapes_ForSubclasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		666674BA168A511400486B68 /* CSSStyleRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 666674B8168A511400486B68 /* CSSStyleRule.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		663FD01B16CBEF5E00CCBFB3 /* BaseClassForAllSVGBasicShapes_ForSubclasses.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 663FD01A16CBEF5C00CCBFB3 /* BaseClassForAllSVGBasicShapes_ForSubclasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		666674BA168A511400486B68 /* CSSStyleRule.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 666674B8168A511400486B68 /* CSSStyleRule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		666674BB168A511400486B68 /* CSSStyleRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 666674B9168A511400486B68 /* CSSStyleRule.m */; };
-		666674C1168A556300486B68 /* StyleSheetList.h in Headers */ = {isa = PBXBuildFile; fileRef = 666674BF168A556200486B68 /* StyleSheetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		666674C1168A556300486B68 /* StyleSheetList.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 666674BF168A556200486B68 /* StyleSheetList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		666674C2168A556300486B68 /* StyleSheetList.m in Sources */ = {isa = PBXBuildFile; fileRef = 666674C0168A556300486B68 /* StyleSheetList.m */; };
-		666674C5168A55AF00486B68 /* StyleSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = 666674C3168A55AD00486B68 /* StyleSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		666674C5168A55AF00486B68 /* StyleSheet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 666674C3168A55AD00486B68 /* StyleSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		666674C6168A55AF00486B68 /* StyleSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 666674C4168A55AE00486B68 /* StyleSheet.m */; };
-		666674C9168A561C00486B68 /* MediaList.h in Headers */ = {isa = PBXBuildFile; fileRef = 666674C7168A561B00486B68 /* MediaList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		666674C9168A561C00486B68 /* MediaList.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 666674C7168A561B00486B68 /* MediaList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		666674CA168A561C00486B68 /* MediaList.m in Sources */ = {isa = PBXBuildFile; fileRef = 666674C8168A561B00486B68 /* MediaList.m */; };
-		6668E2081688D3CF00F774A6 /* SVGGElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 6668E2061688D3CF00F774A6 /* SVGGElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6668E2081688D3CF00F774A6 /* SVGGElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6668E2061688D3CF00F774A6 /* SVGGElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6668E2091688D3CF00F774A6 /* SVGGElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 6668E2071688D3CF00F774A6 /* SVGGElement.m */; };
-		6681C5151CBF07CA00272CCC /* CSSPrimitiveValue_ConfigurablePixelsPerInch.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DD9168A2F4200EC93C7 /* CSSPrimitiveValue_ConfigurablePixelsPerInch.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6681C5161CBF07FB00272CCC /* StyleSheetList+Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 666674CB168A58D000486B68 /* StyleSheetList+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		668418BA1867457900C61EC2 /* SVGKImage+CGContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 668418B81867457900C61EC2 /* SVGKImage+CGContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6681C5151CBF07CA00272CCC /* CSSPrimitiveValue_ConfigurablePixelsPerInch.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DD9168A2F4200EC93C7 /* CSSPrimitiveValue_ConfigurablePixelsPerInch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6681C5161CBF07FB00272CCC /* StyleSheetList+Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 666674CB168A58D000486B68 /* StyleSheetList+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		668418BA1867457900C61EC2 /* SVGKImage+CGContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 668418B81867457900C61EC2 /* SVGKImage+CGContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		668418BB1867457900C61EC2 /* SVGKImage+CGContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 668418B91867457900C61EC2 /* SVGKImage+CGContext.m */; };
-		668418C018674A0300C61EC2 /* SVGKExporterNSData.h in Headers */ = {isa = PBXBuildFile; fileRef = 668418BE18674A0300C61EC2 /* SVGKExporterNSData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		668418C018674A0300C61EC2 /* SVGKExporterNSData.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 668418BE18674A0300C61EC2 /* SVGKExporterNSData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		668418C118674A0300C61EC2 /* SVGKExporterNSData.m in Sources */ = {isa = PBXBuildFile; fileRef = 668418BF18674A0300C61EC2 /* SVGKExporterNSData.m */; };
-		668418C418674BF900C61EC2 /* SVGKExporterUIImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 668418C218674BF900C61EC2 /* SVGKExporterUIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		668418C418674BF900C61EC2 /* SVGKExporterUIImage.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 668418C218674BF900C61EC2 /* SVGKExporterUIImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		668418C518674BF900C61EC2 /* SVGKExporterUIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 668418C318674BF900C61EC2 /* SVGKExporterUIImage.m */; };
-		66849FAD18393EC600AE4F28 /* NamedNodeMap_Iterable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66849FAC18393D3100AE4F28 /* NamedNodeMap_Iterable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6694B5DD199C10400028CFF6 /* SVGKSourceNSData.h in Headers */ = {isa = PBXBuildFile; fileRef = 6694B5DB199C10400028CFF6 /* SVGKSourceNSData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66849FAD18393EC600AE4F28 /* NamedNodeMap_Iterable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66849FAC18393D3100AE4F28 /* NamedNodeMap_Iterable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6694B5DD199C10400028CFF6 /* SVGKSourceNSData.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6694B5DB199C10400028CFF6 /* SVGKSourceNSData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6694B5DE199C10400028CFF6 /* SVGKSourceNSData.m in Sources */ = {isa = PBXBuildFile; fileRef = 6694B5DC199C10400028CFF6 /* SVGKSourceNSData.m */; };
-		6694BB7B16967407007D0947 /* DOMGlobalSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 6694BB7A16967407007D0947 /* DOMGlobalSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66988DB3168A001400EC93C7 /* CSSStyleDeclaration.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DB1168A001400EC93C7 /* CSSStyleDeclaration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6694BB7B16967407007D0947 /* DOMGlobalSettings.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6694BB7A16967407007D0947 /* DOMGlobalSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DB3168A001400EC93C7 /* CSSStyleDeclaration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DB1168A001400EC93C7 /* CSSStyleDeclaration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66988DB4168A001400EC93C7 /* CSSStyleDeclaration.m in Sources */ = {isa = PBXBuildFile; fileRef = 66988DB2168A001400EC93C7 /* CSSStyleDeclaration.m */; };
-		66988DB7168A004D00EC93C7 /* CSSValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DB5168A004D00EC93C7 /* CSSValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DB7168A004D00EC93C7 /* CSSValue.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DB5168A004D00EC93C7 /* CSSValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66988DB8168A004D00EC93C7 /* CSSValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 66988DB6168A004D00EC93C7 /* CSSValue.m */; };
-		66988DBB168A027E00EC93C7 /* CSSRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DB9168A027E00EC93C7 /* CSSRule.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DBB168A027E00EC93C7 /* CSSRule.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DB9168A027E00EC93C7 /* CSSRule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66988DBC168A027E00EC93C7 /* CSSRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 66988DBA168A027E00EC93C7 /* CSSRule.m */; };
-		66988DBF168A031200EC93C7 /* CSSStyleSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DBD168A031100EC93C7 /* CSSStyleSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DBF168A031200EC93C7 /* CSSStyleSheet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DBD168A031100EC93C7 /* CSSStyleSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66988DC0168A031200EC93C7 /* CSSStyleSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 66988DBE168A031100EC93C7 /* CSSStyleSheet.m */; };
-		66988DC3168A038400EC93C7 /* CSSRuleList.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DC1168A038400EC93C7 /* CSSRuleList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DC3168A038400EC93C7 /* CSSRuleList.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DC1168A038400EC93C7 /* CSSRuleList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66988DC4168A038400EC93C7 /* CSSRuleList.m in Sources */ = {isa = PBXBuildFile; fileRef = 66988DC2168A038400EC93C7 /* CSSRuleList.m */; };
-		66988DC7168A04D100EC93C7 /* CSSRuleList+Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DC5168A04D000EC93C7 /* CSSRuleList+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66988DCB168A0A2300EC93C7 /* CSSPrimitiveValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DC9168A0A2300EC93C7 /* CSSPrimitiveValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DC7168A04D100EC93C7 /* CSSRuleList+Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DC5168A04D000EC93C7 /* CSSRuleList+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DCB168A0A2300EC93C7 /* CSSPrimitiveValue.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DC9168A0A2300EC93C7 /* CSSPrimitiveValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66988DCC168A0A2300EC93C7 /* CSSPrimitiveValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 66988DCA168A0A2300EC93C7 /* CSSPrimitiveValue.m */; };
-		66988DCF168A129500EC93C7 /* CSSValueList.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DCD168A129500EC93C7 /* CSSValueList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DCF168A129500EC93C7 /* CSSValueList.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DCD168A129500EC93C7 /* CSSValueList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66988DD0168A129500EC93C7 /* CSSValueList.m in Sources */ = {isa = PBXBuildFile; fileRef = 66988DCE168A129500EC93C7 /* CSSValueList.m */; };
-		66988DD3168A13BD00EC93C7 /* CSSValue_ForSubclasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 66988DD1168A13BC00EC93C7 /* CSSValue_ForSubclasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66988DD3168A13BD00EC93C7 /* CSSValue_ForSubclasses.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66988DD1168A13BC00EC93C7 /* CSSValue_ForSubclasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66DBE4E51C42A00C00A0F0B7 /* SVGKit_iOS-RetainTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DBE4E21C42A00C00A0F0B7 /* SVGKit_iOS-RetainTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		66DBE4E61C42A00C00A0F0B7 /* SVGKit_iOS_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DBE4E31C42A00C00A0F0B7 /* SVGKit_iOS_Tests.m */; };
 		66DBE5011C42A0C900A0F0B7 /* SVGKitFramework_iOSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DBE4FF1C42A0C900A0F0B7 /* SVGKitFramework_iOSTests.m */; };
 		66DBE50D1C42A0D800A0F0B7 /* SVGKitFramework_tvOSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DBE50B1C42A0D800A0F0B7 /* SVGKitFramework_tvOSTests.m */; };
-		66E4E5C4188EF5D3007DFCAA /* SVGKSourceLocalFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 6636CD78175F542A0072AAEF /* SVGKSourceLocalFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E4E5C5188EF5D3007DFCAA /* SVGKSourceString.h in Headers */ = {isa = PBXBuildFile; fileRef = 6636CD7A175F542A0072AAEF /* SVGKSourceString.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E4E5C6188EF5D3007DFCAA /* SVGKSourceURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6636CD7C175F542A0072AAEF /* SVGKSourceURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E8639F1688C2780059C9C4 /* AppleSucksDOMImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8630E1688C2770059C9C4 /* AppleSucksDOMImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E4E5C4188EF5D3007DFCAA /* SVGKSourceLocalFile.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6636CD78175F542A0072AAEF /* SVGKSourceLocalFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E4E5C5188EF5D3007DFCAA /* SVGKSourceString.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6636CD7A175F542A0072AAEF /* SVGKSourceString.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E4E5C6188EF5D3007DFCAA /* SVGKSourceURL.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6636CD7C175F542A0072AAEF /* SVGKSourceURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8639F1688C2780059C9C4 /* AppleSucksDOMImplementation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8630E1688C2770059C9C4 /* AppleSucksDOMImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863A01688C2780059C9C4 /* AppleSucksDOMImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8630F1688C2770059C9C4 /* AppleSucksDOMImplementation.m */; };
-		66E863A11688C2780059C9C4 /* Attr.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863101688C2770059C9C4 /* Attr.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863A11688C2780059C9C4 /* Attr.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863101688C2770059C9C4 /* Attr.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863A21688C2780059C9C4 /* Attr.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863111688C2770059C9C4 /* Attr.m */; };
-		66E863A31688C2780059C9C4 /* CDATASection.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863121688C2770059C9C4 /* CDATASection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863A31688C2780059C9C4 /* CDATASection.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863121688C2770059C9C4 /* CDATASection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863A41688C2780059C9C4 /* CDATASection.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863131688C2770059C9C4 /* CDATASection.m */; };
-		66E863A51688C2780059C9C4 /* CharacterData.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863141688C2770059C9C4 /* CharacterData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863A51688C2780059C9C4 /* CharacterData.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863141688C2770059C9C4 /* CharacterData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863A61688C2780059C9C4 /* CharacterData.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863151688C2770059C9C4 /* CharacterData.m */; };
-		66E863A71688C2780059C9C4 /* Comment.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863161688C2770059C9C4 /* Comment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863A71688C2780059C9C4 /* Comment.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863161688C2770059C9C4 /* Comment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863A81688C2780059C9C4 /* Comment.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863171688C2770059C9C4 /* Comment.m */; };
-		66E863A91688C2780059C9C4 /* Document+Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863181688C2770059C9C4 /* Document+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863AA1688C2780059C9C4 /* Document.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863191688C2770059C9C4 /* Document.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863A91688C2780059C9C4 /* Document+Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863181688C2770059C9C4 /* Document+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863AA1688C2780059C9C4 /* Document.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863191688C2770059C9C4 /* Document.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863AB1688C2780059C9C4 /* Document.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8631A1688C2770059C9C4 /* Document.m */; };
-		66E863AC1688C2780059C9C4 /* DocumentFragment.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8631B1688C2770059C9C4 /* DocumentFragment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863AC1688C2780059C9C4 /* DocumentFragment.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8631B1688C2770059C9C4 /* DocumentFragment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863AD1688C2780059C9C4 /* DocumentFragment.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8631C1688C2770059C9C4 /* DocumentFragment.m */; };
-		66E863AE1688C2780059C9C4 /* DocumentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8631D1688C2770059C9C4 /* DocumentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863AE1688C2780059C9C4 /* DocumentType.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8631D1688C2770059C9C4 /* DocumentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863AF1688C2780059C9C4 /* DocumentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8631E1688C2770059C9C4 /* DocumentType.m */; };
-		66E863B01688C2780059C9C4 /* DOMHelperUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8631F1688C2770059C9C4 /* DOMHelperUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863B01688C2780059C9C4 /* DOMHelperUtilities.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8631F1688C2770059C9C4 /* DOMHelperUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863B11688C2780059C9C4 /* DOMHelperUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863201688C2770059C9C4 /* DOMHelperUtilities.m */; };
-		66E863B21688C2780059C9C4 /* Element.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863211688C2770059C9C4 /* Element.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863B21688C2780059C9C4 /* Element.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863211688C2770059C9C4 /* Element.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863B31688C2780059C9C4 /* Element.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863221688C2770059C9C4 /* Element.m */; };
-		66E863B41688C2780059C9C4 /* EntityReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863231688C2770059C9C4 /* EntityReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863B41688C2780059C9C4 /* EntityReference.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863231688C2770059C9C4 /* EntityReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863B51688C2780059C9C4 /* EntityReference.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863241688C2770059C9C4 /* EntityReference.m */; };
-		66E863B61688C2780059C9C4 /* NamedNodeMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863251688C2770059C9C4 /* NamedNodeMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863B61688C2780059C9C4 /* NamedNodeMap.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863251688C2770059C9C4 /* NamedNodeMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863B71688C2780059C9C4 /* NamedNodeMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863261688C2770059C9C4 /* NamedNodeMap.m */; };
-		66E863B81688C2780059C9C4 /* Node+Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863271688C2770059C9C4 /* Node+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863B91688C2780059C9C4 /* Node.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863281688C2770059C9C4 /* Node.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863B81688C2780059C9C4 /* Node+Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863271688C2770059C9C4 /* Node+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863B91688C2780059C9C4 /* Node.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863281688C2770059C9C4 /* Node.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863BA1688C2780059C9C4 /* Node.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863291688C2770059C9C4 /* Node.m */; };
-		66E863BB1688C2780059C9C4 /* NodeList+Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8632A1688C2770059C9C4 /* NodeList+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863BC1688C2780059C9C4 /* NodeList.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8632B1688C2770059C9C4 /* NodeList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863BB1688C2780059C9C4 /* NodeList+Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8632A1688C2770059C9C4 /* NodeList+Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863BC1688C2780059C9C4 /* NodeList.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8632B1688C2770059C9C4 /* NodeList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863BD1688C2780059C9C4 /* NodeList.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8632C1688C2770059C9C4 /* NodeList.m */; };
-		66E863BE1688C2780059C9C4 /* ProcessingInstruction.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8632D1688C2770059C9C4 /* ProcessingInstruction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863BE1688C2780059C9C4 /* ProcessingInstruction.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8632D1688C2770059C9C4 /* ProcessingInstruction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863BF1688C2780059C9C4 /* ProcessingInstruction.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8632E1688C2770059C9C4 /* ProcessingInstruction.m */; };
-		66E863C01688C2780059C9C4 /* Text.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8632F1688C2770059C9C4 /* Text.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863C01688C2780059C9C4 /* Text.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8632F1688C2770059C9C4 /* Text.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863C11688C2780059C9C4 /* Text.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863301688C2770059C9C4 /* Text.m */; };
-		66E863C21688C2780059C9C4 /* SVGAngle.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863321688C2770059C9C4 /* SVGAngle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863C21688C2780059C9C4 /* SVGAngle.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863321688C2770059C9C4 /* SVGAngle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863C31688C2780059C9C4 /* SVGAngle.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863331688C2770059C9C4 /* SVGAngle.m */; };
-		66E863C41688C2780059C9C4 /* SVGDefsElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863341688C2770059C9C4 /* SVGDefsElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863C41688C2780059C9C4 /* SVGDefsElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863341688C2770059C9C4 /* SVGDefsElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863C51688C2780059C9C4 /* SVGDefsElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863351688C2770059C9C4 /* SVGDefsElement.m */; };
-		66E863C61688C2780059C9C4 /* SVGDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863361688C2770059C9C4 /* SVGDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863C61688C2780059C9C4 /* SVGDocument.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863361688C2770059C9C4 /* SVGDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863C71688C2780059C9C4 /* SVGDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863371688C2770059C9C4 /* SVGDocument.m */; };
-		66E863C81688C2780059C9C4 /* SVGDocument_Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863381688C2770059C9C4 /* SVGDocument_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863C91688C2780059C9C4 /* SVGElementInstance.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863391688C2770059C9C4 /* SVGElementInstance.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863C81688C2780059C9C4 /* SVGDocument_Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863381688C2770059C9C4 /* SVGDocument_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863C91688C2780059C9C4 /* SVGElementInstance.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863391688C2770059C9C4 /* SVGElementInstance.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863CA1688C2780059C9C4 /* SVGElementInstance.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8633A1688C2770059C9C4 /* SVGElementInstance.m */; };
-		66E863CB1688C2780059C9C4 /* SVGElementInstance_Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8633B1688C2770059C9C4 /* SVGElementInstance_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863CC1688C2780059C9C4 /* SVGElementInstanceList.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8633C1688C2770059C9C4 /* SVGElementInstanceList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863CB1688C2780059C9C4 /* SVGElementInstance_Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8633B1688C2770059C9C4 /* SVGElementInstance_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863CC1688C2780059C9C4 /* SVGElementInstanceList.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8633C1688C2770059C9C4 /* SVGElementInstanceList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863CD1688C2780059C9C4 /* SVGElementInstanceList.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8633D1688C2770059C9C4 /* SVGElementInstanceList.m */; };
-		66E863CE1688C2780059C9C4 /* SVGElementInstanceList_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8633E1688C2770059C9C4 /* SVGElementInstanceList_Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863CF1688C2780059C9C4 /* SVGLength.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8633F1688C2770059C9C4 /* SVGLength.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863CE1688C2780059C9C4 /* SVGElementInstanceList_Internal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8633E1688C2770059C9C4 /* SVGElementInstanceList_Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863CF1688C2780059C9C4 /* SVGLength.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8633F1688C2770059C9C4 /* SVGLength.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863D01688C2780059C9C4 /* SVGLength.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863401688C2770059C9C4 /* SVGLength.m */; };
-		66E863D11688C2780059C9C4 /* SVGMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863411688C2770059C9C4 /* SVGMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863D11688C2780059C9C4 /* SVGMatrix.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863411688C2770059C9C4 /* SVGMatrix.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863D21688C2780059C9C4 /* SVGMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863421688C2770059C9C4 /* SVGMatrix.m */; };
-		66E863D31688C2780059C9C4 /* SVGNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863431688C2770059C9C4 /* SVGNumber.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863D41688C2780059C9C4 /* SVGPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863441688C2770059C9C4 /* SVGPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863D31688C2780059C9C4 /* SVGNumber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863431688C2770059C9C4 /* SVGNumber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863D41688C2780059C9C4 /* SVGPoint.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863441688C2770059C9C4 /* SVGPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863D51688C2780059C9C4 /* SVGPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863451688C2770059C9C4 /* SVGPoint.m */; };
-		66E863D61688C2780059C9C4 /* SVGRect.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863461688C2770059C9C4 /* SVGRect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863D71688C2780059C9C4 /* SVGSVGElement_Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863471688C2770059C9C4 /* SVGSVGElement_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863D81688C2780059C9C4 /* SVGTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863481688C2770059C9C4 /* SVGTransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863D61688C2780059C9C4 /* SVGRect.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863461688C2770059C9C4 /* SVGRect.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863D71688C2780059C9C4 /* SVGSVGElement_Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863471688C2770059C9C4 /* SVGSVGElement_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863D81688C2780059C9C4 /* SVGTransform.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863481688C2770059C9C4 /* SVGTransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863D91688C2780059C9C4 /* SVGTransform.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863491688C2770059C9C4 /* SVGTransform.m */; };
-		66E863DA1688C2780059C9C4 /* SVGUseElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8634A1688C2770059C9C4 /* SVGUseElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863DA1688C2780059C9C4 /* SVGUseElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8634A1688C2770059C9C4 /* SVGUseElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863DB1688C2780059C9C4 /* SVGUseElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8634B1688C2770059C9C4 /* SVGUseElement.m */; };
-		66E863DC1688C2780059C9C4 /* SVGUseElement_Mutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8634C1688C2770059C9C4 /* SVGUseElement_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863DD1688C2780059C9C4 /* SVGViewSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8634D1688C2770059C9C4 /* SVGViewSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863DE1688C2780059C9C4 /* SVGCircleElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8634F1688C2770059C9C4 /* SVGCircleElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863DC1688C2780059C9C4 /* SVGUseElement_Mutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8634C1688C2770059C9C4 /* SVGUseElement_Mutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863DD1688C2780059C9C4 /* SVGViewSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8634D1688C2770059C9C4 /* SVGViewSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863DE1688C2780059C9C4 /* SVGCircleElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8634F1688C2770059C9C4 /* SVGCircleElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863DF1688C2780059C9C4 /* SVGCircleElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863501688C2770059C9C4 /* SVGCircleElement.m */; };
-		66E863E01688C2780059C9C4 /* SVGDescriptionElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863511688C2770059C9C4 /* SVGDescriptionElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863E01688C2780059C9C4 /* SVGDescriptionElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863511688C2770059C9C4 /* SVGDescriptionElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863E11688C2780059C9C4 /* SVGDescriptionElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863521688C2770059C9C4 /* SVGDescriptionElement.m */; };
-		66E863E21688C2780059C9C4 /* SVGElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863531688C2770059C9C4 /* SVGElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863E21688C2780059C9C4 /* SVGElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863531688C2770059C9C4 /* SVGElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863E31688C2780059C9C4 /* SVGElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863541688C2770059C9C4 /* SVGElement.m */; };
-		66E863E41688C2780059C9C4 /* SVGElement_ForParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863551688C2770059C9C4 /* SVGElement_ForParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E863E51688C2780059C9C4 /* SVGEllipseElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863561688C2770059C9C4 /* SVGEllipseElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863E41688C2780059C9C4 /* SVGElement_ForParser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863551688C2770059C9C4 /* SVGElement_ForParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863E51688C2780059C9C4 /* SVGEllipseElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863561688C2770059C9C4 /* SVGEllipseElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863E61688C2780059C9C4 /* SVGEllipseElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863571688C2770059C9C4 /* SVGEllipseElement.m */; };
-		66E863E71688C2780059C9C4 /* SVGGroupElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863581688C2770059C9C4 /* SVGGroupElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863E71688C2780059C9C4 /* SVGGroupElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863581688C2770059C9C4 /* SVGGroupElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863E81688C2780059C9C4 /* SVGGroupElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863591688C2770059C9C4 /* SVGGroupElement.m */; };
-		66E863E91688C2780059C9C4 /* SVGImageElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8635A1688C2770059C9C4 /* SVGImageElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863E91688C2780059C9C4 /* SVGImageElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8635A1688C2770059C9C4 /* SVGImageElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863EA1688C2780059C9C4 /* SVGImageElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8635B1688C2770059C9C4 /* SVGImageElement.m */; };
-		66E863EC1688C2780059C9C4 /* SVGLineElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8635D1688C2770059C9C4 /* SVGLineElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863EC1688C2780059C9C4 /* SVGLineElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8635D1688C2770059C9C4 /* SVGLineElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863ED1688C2780059C9C4 /* SVGLineElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8635E1688C2770059C9C4 /* SVGLineElement.m */; };
-		66E863EE1688C2780059C9C4 /* SVGPathElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8635F1688C2770059C9C4 /* SVGPathElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863EE1688C2780059C9C4 /* SVGPathElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8635F1688C2770059C9C4 /* SVGPathElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863EF1688C2780059C9C4 /* SVGPathElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863601688C2770059C9C4 /* SVGPathElement.m */; };
-		66E863F01688C2780059C9C4 /* SVGPolygonElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863611688C2770059C9C4 /* SVGPolygonElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863F01688C2780059C9C4 /* SVGPolygonElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863611688C2770059C9C4 /* SVGPolygonElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863F11688C2780059C9C4 /* SVGPolygonElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863621688C2770059C9C4 /* SVGPolygonElement.m */; };
-		66E863F21688C2780059C9C4 /* SVGPolylineElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863631688C2770059C9C4 /* SVGPolylineElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863F21688C2780059C9C4 /* SVGPolylineElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863631688C2770059C9C4 /* SVGPolylineElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863F31688C2780059C9C4 /* SVGPolylineElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863641688C2770059C9C4 /* SVGPolylineElement.m */; };
-		66E863F41688C2780059C9C4 /* SVGRectElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863651688C2770059C9C4 /* SVGRectElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863F41688C2780059C9C4 /* SVGRectElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863651688C2770059C9C4 /* SVGRectElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863F51688C2780059C9C4 /* SVGRectElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863661688C2770059C9C4 /* SVGRectElement.m */; };
-		66E863F61688C2780059C9C4 /* BaseClassForAllSVGBasicShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863671688C2770059C9C4 /* BaseClassForAllSVGBasicShapes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863F61688C2780059C9C4 /* BaseClassForAllSVGBasicShapes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863671688C2770059C9C4 /* BaseClassForAllSVGBasicShapes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863F71688C2780059C9C4 /* BaseClassForAllSVGBasicShapes.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863681688C2770059C9C4 /* BaseClassForAllSVGBasicShapes.m */; };
-		66E863F81688C2780059C9C4 /* SVGSVGElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863691688C2770059C9C4 /* SVGSVGElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863F81688C2780059C9C4 /* SVGSVGElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863691688C2770059C9C4 /* SVGSVGElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863F91688C2780059C9C4 /* SVGSVGElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8636A1688C2770059C9C4 /* SVGSVGElement.m */; };
-		66E863FA1688C2780059C9C4 /* SVGTextElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8636B1688C2770059C9C4 /* SVGTextElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863FA1688C2780059C9C4 /* SVGTextElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8636B1688C2770059C9C4 /* SVGTextElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863FB1688C2780059C9C4 /* SVGTextElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8636C1688C2770059C9C4 /* SVGTextElement.m */; };
-		66E863FC1688C2780059C9C4 /* SVGTitleElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8636D1688C2770059C9C4 /* SVGTitleElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E863FC1688C2780059C9C4 /* SVGTitleElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8636D1688C2770059C9C4 /* SVGTitleElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E863FD1688C2780059C9C4 /* SVGTitleElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8636E1688C2770059C9C4 /* SVGTitleElement.m */; };
-		66E864001688C2780059C9C4 /* SVGKParserDefsAndUse.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863741688C2770059C9C4 /* SVGKParserDefsAndUse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864001688C2780059C9C4 /* SVGKParserDefsAndUse.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863741688C2770059C9C4 /* SVGKParserDefsAndUse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864011688C2780059C9C4 /* SVGKParserDefsAndUse.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863751688C2770059C9C4 /* SVGKParserDefsAndUse.m */; };
-		66E864021688C2780059C9C4 /* SVGKParserDOM.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863761688C2770059C9C4 /* SVGKParserDOM.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864021688C2780059C9C4 /* SVGKParserDOM.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863761688C2770059C9C4 /* SVGKParserDOM.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864031688C2780059C9C4 /* SVGKParserDOM.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863771688C2770059C9C4 /* SVGKParserDOM.m */; };
-		66E864041688C2780059C9C4 /* SVGKParserPatternsAndGradients.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863781688C2770059C9C4 /* SVGKParserPatternsAndGradients.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864041688C2780059C9C4 /* SVGKParserPatternsAndGradients.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863781688C2770059C9C4 /* SVGKParserPatternsAndGradients.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864051688C2780059C9C4 /* SVGKParserPatternsAndGradients.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863791688C2770059C9C4 /* SVGKParserPatternsAndGradients.m */; };
-		66E864061688C2780059C9C4 /* SVGKParserSVG.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8637A1688C2770059C9C4 /* SVGKParserSVG.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864061688C2780059C9C4 /* SVGKParserSVG.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8637A1688C2770059C9C4 /* SVGKParserSVG.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864071688C2780059C9C4 /* SVGKParserSVG.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8637B1688C2770059C9C4 /* SVGKParserSVG.m */; };
-		66E864081688C2780059C9C4 /* SVGKParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8637C1688C2770059C9C4 /* SVGKParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864081688C2780059C9C4 /* SVGKParser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8637C1688C2770059C9C4 /* SVGKParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864091688C2780059C9C4 /* SVGKParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8637D1688C2770059C9C4 /* SVGKParser.m */; };
-		66E8640A1688C2780059C9C4 /* SVGKParseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8637E1688C2770059C9C4 /* SVGKParseResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8640A1688C2780059C9C4 /* SVGKParseResult.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8637E1688C2770059C9C4 /* SVGKParseResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E8640B1688C2780059C9C4 /* SVGKParseResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8637F1688C2770059C9C4 /* SVGKParseResult.m */; };
-		66E8640C1688C2780059C9C4 /* SVGKParserExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863801688C2770059C9C4 /* SVGKParserExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E8640D1688C2780059C9C4 /* SVGKPointsAndPathsParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863811688C2770059C9C4 /* SVGKPointsAndPathsParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8640C1688C2780059C9C4 /* SVGKParserExtension.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863801688C2770059C9C4 /* SVGKParserExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8640D1688C2780059C9C4 /* SVGKPointsAndPathsParser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863811688C2770059C9C4 /* SVGKPointsAndPathsParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E8640E1688C2780059C9C4 /* SVGKPointsAndPathsParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863821688C2770059C9C4 /* SVGKPointsAndPathsParser.m */; };
-		66E8640F1688C2780059C9C4 /* CALayerWithChildHitTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863841688C2770059C9C4 /* CALayerWithChildHitTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8640F1688C2780059C9C4 /* CALayerWithChildHitTest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863841688C2770059C9C4 /* CALayerWithChildHitTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864101688C2780059C9C4 /* CALayerWithChildHitTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863851688C2770059C9C4 /* CALayerWithChildHitTest.m */; };
-		66E864111688C2780059C9C4 /* CAShapeLayerWithHitTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863861688C2770059C9C4 /* CAShapeLayerWithHitTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864111688C2780059C9C4 /* CAShapeLayerWithHitTest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863861688C2770059C9C4 /* CAShapeLayerWithHitTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864121688C2780059C9C4 /* CAShapeLayerWithHitTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863871688C2770059C9C4 /* CAShapeLayerWithHitTest.m */; };
-		66E864131688C2780059C9C4 /* CGPathAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863881688C2770059C9C4 /* CGPathAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864131688C2780059C9C4 /* CGPathAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863881688C2770059C9C4 /* CGPathAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864141688C2780059C9C4 /* CGPathAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863891688C2770059C9C4 /* CGPathAdditions.m */; };
-		66E864151688C2780059C9C4 /* SVGKLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8638A1688C2780059C9C4 /* SVGKLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864151688C2780059C9C4 /* SVGKLayer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8638A1688C2780059C9C4 /* SVGKLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864161688C2780059C9C4 /* SVGKLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8638B1688C2780059C9C4 /* SVGKLayer.m */; };
-		66E864171688C2780059C9C4 /* SVGKImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8638C1688C2780059C9C4 /* SVGKImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864171688C2780059C9C4 /* SVGKImage.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8638C1688C2780059C9C4 /* SVGKImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864181688C2780059C9C4 /* SVGKImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8638D1688C2780059C9C4 /* SVGKImage.m */; };
-		66E864191688C2780059C9C4 /* SVGKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8638E1688C2780059C9C4 /* SVGKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66E8641A1688C2780059C9C4 /* SVGKSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8638F1688C2780059C9C4 /* SVGKSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864191688C2780059C9C4 /* SVGKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8638E1688C2780059C9C4 /* SVGKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8641A1688C2780059C9C4 /* SVGKSource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8638F1688C2780059C9C4 /* SVGKSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E8641B1688C2780059C9C4 /* SVGKSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863901688C2780059C9C4 /* SVGKSource.m */; };
-		66E8641C1688C2780059C9C4 /* SVGKFastImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863921688C2780059C9C4 /* SVGKFastImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8641C1688C2780059C9C4 /* SVGKFastImageView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863921688C2780059C9C4 /* SVGKFastImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E8641D1688C2780059C9C4 /* SVGKFastImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863931688C2780059C9C4 /* SVGKFastImageView.m */; };
-		66E8641E1688C2780059C9C4 /* SVGKImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863941688C2780059C9C4 /* SVGKImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E8641E1688C2780059C9C4 /* SVGKImageView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863941688C2780059C9C4 /* SVGKImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E8641F1688C2780059C9C4 /* SVGKImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863951688C2780059C9C4 /* SVGKImageView.m */; };
-		66E864201688C2780059C9C4 /* SVGKLayeredImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E863961688C2780059C9C4 /* SVGKLayeredImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864201688C2780059C9C4 /* SVGKLayeredImageView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E863961688C2780059C9C4 /* SVGKLayeredImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864211688C2780059C9C4 /* SVGKLayeredImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E863971688C2780059C9C4 /* SVGKLayeredImageView.m */; };
-		66E864241688C2780059C9C4 /* SVGKPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8639B1688C2780059C9C4 /* SVGKPattern.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864241688C2780059C9C4 /* SVGKPattern.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8639B1688C2780059C9C4 /* SVGKPattern.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864251688C2780059C9C4 /* SVGKPattern.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8639C1688C2780059C9C4 /* SVGKPattern.m */; };
-		66E864261688C2780059C9C4 /* SVGUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 66E8639D1688C2780059C9C4 /* SVGUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66E864261688C2780059C9C4 /* SVGUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66E8639D1688C2780059C9C4 /* SVGUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66E864271688C2780059C9C4 /* SVGUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8639E1688C2780059C9C4 /* SVGUtils.m */; };
-		66EEE8521688CA8A002E2658 /* SVGKParserGradient.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EEE8501688CA8A002E2658 /* SVGKParserGradient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66EEE8521688CA8A002E2658 /* SVGKParserGradient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66EEE8501688CA8A002E2658 /* SVGKParserGradient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66EEE8531688CA8A002E2658 /* SVGKParserGradient.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EEE8511688CA8A002E2658 /* SVGKParserGradient.m */; };
-		66EEE8571688CA94002E2658 /* SVGKParserStyles.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EEE8551688CA94002E2658 /* SVGKParserStyles.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66EEE8571688CA94002E2658 /* SVGKParserStyles.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66EEE8551688CA94002E2658 /* SVGKParserStyles.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66EEE8581688CA94002E2658 /* SVGKParserStyles.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EEE8561688CA94002E2658 /* SVGKParserStyles.m */; };
-		66EEE8601688CB37002E2658 /* SVGGradientElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EEE8591688CB37002E2658 /* SVGGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66EEE8601688CB37002E2658 /* SVGGradientElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66EEE8591688CB37002E2658 /* SVGGradientElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66EEE8611688CB37002E2658 /* SVGGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EEE85A1688CB37002E2658 /* SVGGradientElement.m */; };
-		66EEE8621688CB37002E2658 /* SVGGradientStop.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EEE85B1688CB37002E2658 /* SVGGradientStop.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66EEE8621688CB37002E2658 /* SVGGradientStop.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66EEE85B1688CB37002E2658 /* SVGGradientStop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66EEE8631688CB37002E2658 /* SVGGradientStop.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EEE85C1688CB37002E2658 /* SVGGradientStop.m */; };
-		66EEE8641688CB37002E2658 /* SVGStyleCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EEE85D1688CB37002E2658 /* SVGStyleCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66EEE8651688CB37002E2658 /* SVGStyleElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EEE85E1688CB37002E2658 /* SVGStyleElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66EEE8641688CB37002E2658 /* SVGStyleCatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66EEE85D1688CB37002E2658 /* SVGStyleCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66EEE8651688CB37002E2658 /* SVGStyleElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66EEE85E1688CB37002E2658 /* SVGStyleElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66EEE8661688CB37002E2658 /* SVGStyleElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EEE85F1688CB37002E2658 /* SVGStyleElement.m */; };
-		66F33DD0182FE1C4004464AC /* SVGPreserveAspectRatio.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F33DCE182FE1C4004464AC /* SVGPreserveAspectRatio.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66F33DD0182FE1C4004464AC /* SVGPreserveAspectRatio.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66F33DCE182FE1C4004464AC /* SVGPreserveAspectRatio.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66F33DD1182FE1C4004464AC /* SVGPreserveAspectRatio.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F33DCF182FE1C4004464AC /* SVGPreserveAspectRatio.m */; };
-		66F33DD4182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F33DD2182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66F33DD4182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 66F33DD2182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66F33DD5182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F33DD3182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.m */; };
 		825CDAB91BDA4BC0003C1C12 /* SVGKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 825CDAAF1BDA4BC0003C1C12 /* SVGKit.framework */; };
 		825CDAC91BDA4D09003C1C12 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639634116148CDF00E58CCA /* QuartzCore.framework */; };
@@ -964,18 +962,18 @@
 		825CDCBE1BDA5144003C1C12 /* SVGUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 66E8639E1688C2780059C9C4 /* SVGUtils.m */; };
 		825CDCC51BDA5314003C1C12 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 825CDACC1BDA4D20003C1C12 /* libxml2.tbd */; };
 		825CDCC61BDA531A003C1C12 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 825CDAF31BDA4E1F003C1C12 /* libxml2.tbd */; };
-		9ED79A24179D87790048AA5B /* SVGGradientLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9ED79A22179D87790048AA5B /* SVGGradientLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9ED79A24179D87790048AA5B /* SVGGradientLayer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9ED79A22179D87790048AA5B /* SVGGradientLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9ED79A25179D87790048AA5B /* SVGGradientLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9ED79A23179D87790048AA5B /* SVGGradientLayer.m */; };
-		BD0AFF8C19AE442F0001578E /* SVGUnitTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BD2F8C4E199D0792008AE06D /* SVGUnitTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD1585731996B13F00461AA5 /* NSData+NSInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = BD1585721996B13F00461AA5 /* NSData+NSInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD0AFF8C19AE442F0001578E /* SVGUnitTypes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = BD2F8C4E199D0792008AE06D /* SVGUnitTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD1585731996B13F00461AA5 /* NSData+NSInputStream.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = BD1585721996B13F00461AA5 /* NSData+NSInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD1585751996B17C00461AA5 /* NSData+NSInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = BD1585741996B17C00461AA5 /* NSData+NSInputStream.m */; };
-		BD2F8C51199D0897008AE06D /* SVGClipPathElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BD2F8C4F199D0897008AE06D /* SVGClipPathElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD2F8C51199D0897008AE06D /* SVGClipPathElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = BD2F8C4F199D0897008AE06D /* SVGClipPathElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD2F8C52199D0897008AE06D /* SVGClipPathElement.m in Sources */ = {isa = PBXBuildFile; fileRef = BD2F8C50199D0897008AE06D /* SVGClipPathElement.m */; };
-		BD2F8C55199D14D6008AE06D /* CALayerWithClipRender.h in Headers */ = {isa = PBXBuildFile; fileRef = BD2F8C53199D14D6008AE06D /* CALayerWithClipRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD2F8C55199D14D6008AE06D /* CALayerWithClipRender.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = BD2F8C53199D14D6008AE06D /* CALayerWithClipRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD2F8C56199D14D6008AE06D /* CALayerWithClipRender.m in Sources */ = {isa = PBXBuildFile; fileRef = BD2F8C54199D14D6008AE06D /* CALayerWithClipRender.m */; };
-		BD4C56DC199D55CC00AF04AD /* CAShapeLayerWithClipRender.h in Headers */ = {isa = PBXBuildFile; fileRef = BD4C56DA199D55CC00AF04AD /* CAShapeLayerWithClipRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD4C56DC199D55CC00AF04AD /* CAShapeLayerWithClipRender.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = BD4C56DA199D55CC00AF04AD /* CAShapeLayerWithClipRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD4C56DD199D55CC00AF04AD /* CAShapeLayerWithClipRender.m in Sources */ = {isa = PBXBuildFile; fileRef = BD4C56DB199D55CC00AF04AD /* CAShapeLayerWithClipRender.m */; };
-		BDA133B719AD0E81003C9945 /* TinySVGTextAreaElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BDA133B519AD0E81003C9945 /* TinySVGTextAreaElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDA133B719AD0E81003C9945 /* TinySVGTextAreaElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = BDA133B519AD0E81003C9945 /* TinySVGTextAreaElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BDA133B819AD0E81003C9945 /* TinySVGTextAreaElement.m in Sources */ = {isa = PBXBuildFile; fileRef = BDA133B619AD0E81003C9945 /* TinySVGTextAreaElement.m */; };
 /* End PBXBuildFile section */
 
@@ -1011,6 +1009,147 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		58F90EB5294189040074192B /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				66E8639F1688C2780059C9C4 /* AppleSucksDOMImplementation.h in CopyFiles */,
+				66E4E5C4188EF5D3007DFCAA /* SVGKSourceLocalFile.h in CopyFiles */,
+				6681C5161CBF07FB00272CCC /* StyleSheetList+Mutable.h in CopyFiles */,
+				6681C5151CBF07CA00272CCC /* CSSPrimitiveValue_ConfigurablePixelsPerInch.h in CopyFiles */,
+				66E4E5C5188EF5D3007DFCAA /* SVGKSourceString.h in CopyFiles */,
+				66E4E5C6188EF5D3007DFCAA /* SVGKSourceURL.h in CopyFiles */,
+				66849FAD18393EC600AE4F28 /* NamedNodeMap_Iterable.h in CopyFiles */,
+				66E863A11688C2780059C9C4 /* Attr.h in CopyFiles */,
+				66E863A31688C2780059C9C4 /* CDATASection.h in CopyFiles */,
+				32D3D5DF2176E01400ED20D8 /* SVGRadialGradientElement.h in CopyFiles */,
+				66E863A51688C2780059C9C4 /* CharacterData.h in CopyFiles */,
+				66E863A71688C2780059C9C4 /* Comment.h in CopyFiles */,
+				66E863A91688C2780059C9C4 /* Document+Mutable.h in CopyFiles */,
+				66E863AA1688C2780059C9C4 /* Document.h in CopyFiles */,
+				66372EEE1695F16A008C6C56 /* DocumentCSS.h in CopyFiles */,
+				66E863AC1688C2780059C9C4 /* DocumentFragment.h in CopyFiles */,
+				66372EEF1695F17F008C6C56 /* DocumentStyle.h in CopyFiles */,
+				66E863AE1688C2780059C9C4 /* DocumentType.h in CopyFiles */,
+				32C4891E21916F3D007B1F29 /* SVGTextLayer.h in CopyFiles */,
+				66E863B01688C2780059C9C4 /* DOMHelperUtilities.h in CopyFiles */,
+				66E863B21688C2780059C9C4 /* Element.h in CopyFiles */,
+				66E863B41688C2780059C9C4 /* EntityReference.h in CopyFiles */,
+				66E863B61688C2780059C9C4 /* NamedNodeMap.h in CopyFiles */,
+				66E863B81688C2780059C9C4 /* Node+Mutable.h in CopyFiles */,
+				66E863B91688C2780059C9C4 /* Node.h in CopyFiles */,
+				66E863BB1688C2780059C9C4 /* NodeList+Mutable.h in CopyFiles */,
+				66E863BC1688C2780059C9C4 /* NodeList.h in CopyFiles */,
+				66E863BE1688C2780059C9C4 /* ProcessingInstruction.h in CopyFiles */,
+				66E863C01688C2780059C9C4 /* Text.h in CopyFiles */,
+				66E863C21688C2780059C9C4 /* SVGAngle.h in CopyFiles */,
+				66E863C41688C2780059C9C4 /* SVGDefsElement.h in CopyFiles */,
+				66E863C61688C2780059C9C4 /* SVGDocument.h in CopyFiles */,
+				66E863C81688C2780059C9C4 /* SVGDocument_Mutable.h in CopyFiles */,
+				66E863C91688C2780059C9C4 /* SVGElementInstance.h in CopyFiles */,
+				66E863CB1688C2780059C9C4 /* SVGElementInstance_Mutable.h in CopyFiles */,
+				66E863CC1688C2780059C9C4 /* SVGElementInstanceList.h in CopyFiles */,
+				66E863CE1688C2780059C9C4 /* SVGElementInstanceList_Internal.h in CopyFiles */,
+				66E863CF1688C2780059C9C4 /* SVGLength.h in CopyFiles */,
+				66E863D11688C2780059C9C4 /* SVGMatrix.h in CopyFiles */,
+				66E863D31688C2780059C9C4 /* SVGNumber.h in CopyFiles */,
+				66E863D41688C2780059C9C4 /* SVGPoint.h in CopyFiles */,
+				66E863D61688C2780059C9C4 /* SVGRect.h in CopyFiles */,
+				668418C418674BF900C61EC2 /* SVGKExporterUIImage.h in CopyFiles */,
+				66E863D71688C2780059C9C4 /* SVGSVGElement_Mutable.h in CopyFiles */,
+				66E863D81688C2780059C9C4 /* SVGTransform.h in CopyFiles */,
+				66E863DA1688C2780059C9C4 /* SVGUseElement.h in CopyFiles */,
+				66E863DC1688C2780059C9C4 /* SVGUseElement_Mutable.h in CopyFiles */,
+				66E863DD1688C2780059C9C4 /* SVGViewSpec.h in CopyFiles */,
+				66E863DE1688C2780059C9C4 /* SVGCircleElement.h in CopyFiles */,
+				66E863E01688C2780059C9C4 /* SVGDescriptionElement.h in CopyFiles */,
+				66E863E21688C2780059C9C4 /* SVGElement.h in CopyFiles */,
+				66E863E41688C2780059C9C4 /* SVGElement_ForParser.h in CopyFiles */,
+				66E863E51688C2780059C9C4 /* SVGEllipseElement.h in CopyFiles */,
+				66E863E71688C2780059C9C4 /* SVGGroupElement.h in CopyFiles */,
+				32EE37972173441400A23278 /* SVGKDefine.h in CopyFiles */,
+				66E863E91688C2780059C9C4 /* SVGImageElement.h in CopyFiles */,
+				668418BA1867457900C61EC2 /* SVGKImage+CGContext.h in CopyFiles */,
+				66E863EC1688C2780059C9C4 /* SVGLineElement.h in CopyFiles */,
+				66E863EE1688C2780059C9C4 /* SVGPathElement.h in CopyFiles */,
+				66E863F01688C2780059C9C4 /* SVGPolygonElement.h in CopyFiles */,
+				66E863F21688C2780059C9C4 /* SVGPolylineElement.h in CopyFiles */,
+				66E863F41688C2780059C9C4 /* SVGRectElement.h in CopyFiles */,
+				66E863F61688C2780059C9C4 /* BaseClassForAllSVGBasicShapes.h in CopyFiles */,
+				66E863F81688C2780059C9C4 /* SVGSVGElement.h in CopyFiles */,
+				66E863FA1688C2780059C9C4 /* SVGTextElement.h in CopyFiles */,
+				66E863FC1688C2780059C9C4 /* SVGTitleElement.h in CopyFiles */,
+				66E864001688C2780059C9C4 /* SVGKParserDefsAndUse.h in CopyFiles */,
+				66E864021688C2780059C9C4 /* SVGKParserDOM.h in CopyFiles */,
+				66E864041688C2780059C9C4 /* SVGKParserPatternsAndGradients.h in CopyFiles */,
+				66E864061688C2780059C9C4 /* SVGKParserSVG.h in CopyFiles */,
+				66E864081688C2780059C9C4 /* SVGKParser.h in CopyFiles */,
+				66E8640A1688C2780059C9C4 /* SVGKParseResult.h in CopyFiles */,
+				66E8640C1688C2780059C9C4 /* SVGKParserExtension.h in CopyFiles */,
+				66E8640D1688C2780059C9C4 /* SVGKPointsAndPathsParser.h in CopyFiles */,
+				66E8640F1688C2780059C9C4 /* CALayerWithChildHitTest.h in CopyFiles */,
+				66E864111688C2780059C9C4 /* CAShapeLayerWithHitTest.h in CopyFiles */,
+				663403A4188EFC8A0077005F /* CALayer+RecursiveClone.h in CopyFiles */,
+				322A5B7D218BF990003D9CF1 /* SVGKInlineResource.h in CopyFiles */,
+				66E864131688C2780059C9C4 /* CGPathAdditions.h in CopyFiles */,
+				66E864151688C2780059C9C4 /* SVGKLayer.h in CopyFiles */,
+				66E864171688C2780059C9C4 /* SVGKImage.h in CopyFiles */,
+				66E864191688C2780059C9C4 /* SVGKit.h in CopyFiles */,
+				66E8641A1688C2780059C9C4 /* SVGKSource.h in CopyFiles */,
+				66E8641C1688C2780059C9C4 /* SVGKFastImageView.h in CopyFiles */,
+				66E8641E1688C2780059C9C4 /* SVGKImageView.h in CopyFiles */,
+				66E864201688C2780059C9C4 /* SVGKLayeredImageView.h in CopyFiles */,
+				66E864241688C2780059C9C4 /* SVGKPattern.h in CopyFiles */,
+				66E864261688C2780059C9C4 /* SVGUtils.h in CopyFiles */,
+				66EEE8521688CA8A002E2658 /* SVGKParserGradient.h in CopyFiles */,
+				66EEE8571688CA94002E2658 /* SVGKParserStyles.h in CopyFiles */,
+				66EEE8601688CB37002E2658 /* SVGGradientElement.h in CopyFiles */,
+				66EEE8621688CB37002E2658 /* SVGGradientStop.h in CopyFiles */,
+				66EEE8641688CB37002E2658 /* SVGStyleCatcher.h in CopyFiles */,
+				66EEE8651688CB37002E2658 /* SVGStyleElement.h in CopyFiles */,
+				66372EF01695F193008C6C56 /* SVGStylable.h in CopyFiles */,
+				6668E2081688D3CF00F774A6 /* SVGGElement.h in CopyFiles */,
+				66988DB3168A001400EC93C7 /* CSSStyleDeclaration.h in CopyFiles */,
+				66988DB7168A004D00EC93C7 /* CSSValue.h in CopyFiles */,
+				66988DBB168A027E00EC93C7 /* CSSRule.h in CopyFiles */,
+				668418C018674A0300C61EC2 /* SVGKExporterNSData.h in CopyFiles */,
+				66988DBF168A031200EC93C7 /* CSSStyleSheet.h in CopyFiles */,
+				66988DC3168A038400EC93C7 /* CSSRuleList.h in CopyFiles */,
+				66988DC7168A04D100EC93C7 /* CSSRuleList+Mutable.h in CopyFiles */,
+				66988DCB168A0A2300EC93C7 /* CSSPrimitiveValue.h in CopyFiles */,
+				66988DCF168A129500EC93C7 /* CSSValueList.h in CopyFiles */,
+				32D3D5DA2176E00E00ED20D8 /* SVGLinearGradientElement.h in CopyFiles */,
+				66988DD3168A13BD00EC93C7 /* CSSValue_ForSubclasses.h in CopyFiles */,
+				666674BA168A511400486B68 /* CSSStyleRule.h in CopyFiles */,
+				666674C1168A556300486B68 /* StyleSheetList.h in CopyFiles */,
+				666674C5168A55AF00486B68 /* StyleSheet.h in CopyFiles */,
+				666674C9168A561C00486B68 /* MediaList.h in CopyFiles */,
+				6694BB7B16967407007D0947 /* DOMGlobalSettings.h in CopyFiles */,
+				663FD01416CAEF0D00CCBFB3 /* SVGHelperUtilities.h in CopyFiles */,
+				663FD01B16CBEF5E00CCBFB3 /* BaseClassForAllSVGBasicShapes_ForSubclasses.h in CopyFiles */,
+				661ADBF216CC2FBE006F4BC3 /* SVGTextPositioningElement.h in CopyFiles */,
+				661ADBF716CC2FCA006F4BC3 /* SVGTextContentElement.h in CopyFiles */,
+				661ADBFC16CC364F006F4BC3 /* SVGTextPositioningElement_Mutable.h in CopyFiles */,
+				661AE44916D13DA8005E69D9 /* SVGTransformable.h in CopyFiles */,
+				661AE44A16D13DAD005E69D9 /* SVGFitToViewBox.h in CopyFiles */,
+				036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in CopyFiles */,
+				6636CD8D175F54970072AAEF /* ConverterSVGToCALayer.h in CopyFiles */,
+				66F33DD0182FE1C4004464AC /* SVGPreserveAspectRatio.h in CopyFiles */,
+				66F33DD4182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.h in CopyFiles */,
+				9ED79A24179D87790048AA5B /* SVGGradientLayer.h in CopyFiles */,
+				BD2F8C51199D0897008AE06D /* SVGClipPathElement.h in CopyFiles */,
+				BD4C56DC199D55CC00AF04AD /* CAShapeLayerWithClipRender.h in CopyFiles */,
+				BDA133B719AD0E81003C9945 /* TinySVGTextAreaElement.h in CopyFiles */,
+				BD2F8C55199D14D6008AE06D /* CALayerWithClipRender.h in CopyFiles */,
+				6694B5DD199C10400028CFF6 /* SVGKSourceNSData.h in CopyFiles */,
+				BD1585731996B13F00461AA5 /* NSData+NSInputStream.h in CopyFiles */,
+				4FD821F01AC69F6600E419D3 /* SVGSwitchElement.h in CopyFiles */,
+				BD0AFF8C19AE442F0001578E /* SVGUnitTypes.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6639618C16145D0400E58CCA /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2106,147 +2245,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6639624616145D3E00E58CCA /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66E8639F1688C2780059C9C4 /* AppleSucksDOMImplementation.h in Headers */,
-				66E4E5C4188EF5D3007DFCAA /* SVGKSourceLocalFile.h in Headers */,
-				6681C5161CBF07FB00272CCC /* StyleSheetList+Mutable.h in Headers */,
-				6681C5151CBF07CA00272CCC /* CSSPrimitiveValue_ConfigurablePixelsPerInch.h in Headers */,
-				66E4E5C5188EF5D3007DFCAA /* SVGKSourceString.h in Headers */,
-				66E4E5C6188EF5D3007DFCAA /* SVGKSourceURL.h in Headers */,
-				66849FAD18393EC600AE4F28 /* NamedNodeMap_Iterable.h in Headers */,
-				66E863A11688C2780059C9C4 /* Attr.h in Headers */,
-				66E863A31688C2780059C9C4 /* CDATASection.h in Headers */,
-				32D3D5DF2176E01400ED20D8 /* SVGRadialGradientElement.h in Headers */,
-				66E863A51688C2780059C9C4 /* CharacterData.h in Headers */,
-				66E863A71688C2780059C9C4 /* Comment.h in Headers */,
-				66E863A91688C2780059C9C4 /* Document+Mutable.h in Headers */,
-				66E863AA1688C2780059C9C4 /* Document.h in Headers */,
-				66372EEE1695F16A008C6C56 /* DocumentCSS.h in Headers */,
-				66E863AC1688C2780059C9C4 /* DocumentFragment.h in Headers */,
-				66372EEF1695F17F008C6C56 /* DocumentStyle.h in Headers */,
-				66E863AE1688C2780059C9C4 /* DocumentType.h in Headers */,
-				32C4891E21916F3D007B1F29 /* SVGTextLayer.h in Headers */,
-				66E863B01688C2780059C9C4 /* DOMHelperUtilities.h in Headers */,
-				66E863B21688C2780059C9C4 /* Element.h in Headers */,
-				66E863B41688C2780059C9C4 /* EntityReference.h in Headers */,
-				66E863B61688C2780059C9C4 /* NamedNodeMap.h in Headers */,
-				66E863B81688C2780059C9C4 /* Node+Mutable.h in Headers */,
-				66E863B91688C2780059C9C4 /* Node.h in Headers */,
-				66E863BB1688C2780059C9C4 /* NodeList+Mutable.h in Headers */,
-				66E863BC1688C2780059C9C4 /* NodeList.h in Headers */,
-				66E863BE1688C2780059C9C4 /* ProcessingInstruction.h in Headers */,
-				66E863C01688C2780059C9C4 /* Text.h in Headers */,
-				66E863C21688C2780059C9C4 /* SVGAngle.h in Headers */,
-				66E863C41688C2780059C9C4 /* SVGDefsElement.h in Headers */,
-				66E863C61688C2780059C9C4 /* SVGDocument.h in Headers */,
-				66E863C81688C2780059C9C4 /* SVGDocument_Mutable.h in Headers */,
-				66E863C91688C2780059C9C4 /* SVGElementInstance.h in Headers */,
-				66E863CB1688C2780059C9C4 /* SVGElementInstance_Mutable.h in Headers */,
-				66E863CC1688C2780059C9C4 /* SVGElementInstanceList.h in Headers */,
-				66E863CE1688C2780059C9C4 /* SVGElementInstanceList_Internal.h in Headers */,
-				66E863CF1688C2780059C9C4 /* SVGLength.h in Headers */,
-				66E863D11688C2780059C9C4 /* SVGMatrix.h in Headers */,
-				66E863D31688C2780059C9C4 /* SVGNumber.h in Headers */,
-				66E863D41688C2780059C9C4 /* SVGPoint.h in Headers */,
-				66E863D61688C2780059C9C4 /* SVGRect.h in Headers */,
-				668418C418674BF900C61EC2 /* SVGKExporterUIImage.h in Headers */,
-				66E863D71688C2780059C9C4 /* SVGSVGElement_Mutable.h in Headers */,
-				66E863D81688C2780059C9C4 /* SVGTransform.h in Headers */,
-				66E863DA1688C2780059C9C4 /* SVGUseElement.h in Headers */,
-				66E863DC1688C2780059C9C4 /* SVGUseElement_Mutable.h in Headers */,
-				66E863DD1688C2780059C9C4 /* SVGViewSpec.h in Headers */,
-				66E863DE1688C2780059C9C4 /* SVGCircleElement.h in Headers */,
-				66E863E01688C2780059C9C4 /* SVGDescriptionElement.h in Headers */,
-				582A6AFB283AEEA60057FEAF /* NamespacedDependencies.h in Headers */,
-				66E863E21688C2780059C9C4 /* SVGElement.h in Headers */,
-				66E863E41688C2780059C9C4 /* SVGElement_ForParser.h in Headers */,
-				66E863E51688C2780059C9C4 /* SVGEllipseElement.h in Headers */,
-				66E863E71688C2780059C9C4 /* SVGGroupElement.h in Headers */,
-				32EE37972173441400A23278 /* SVGKDefine.h in Headers */,
-				66E863E91688C2780059C9C4 /* SVGImageElement.h in Headers */,
-				668418BA1867457900C61EC2 /* SVGKImage+CGContext.h in Headers */,
-				66E863EC1688C2780059C9C4 /* SVGLineElement.h in Headers */,
-				66E863EE1688C2780059C9C4 /* SVGPathElement.h in Headers */,
-				66E863F01688C2780059C9C4 /* SVGPolygonElement.h in Headers */,
-				66E863F21688C2780059C9C4 /* SVGPolylineElement.h in Headers */,
-				66E863F41688C2780059C9C4 /* SVGRectElement.h in Headers */,
-				66E863F61688C2780059C9C4 /* BaseClassForAllSVGBasicShapes.h in Headers */,
-				66E863F81688C2780059C9C4 /* SVGSVGElement.h in Headers */,
-				66E863FA1688C2780059C9C4 /* SVGTextElement.h in Headers */,
-				66E863FC1688C2780059C9C4 /* SVGTitleElement.h in Headers */,
-				66E864001688C2780059C9C4 /* SVGKParserDefsAndUse.h in Headers */,
-				66E864021688C2780059C9C4 /* SVGKParserDOM.h in Headers */,
-				66E864041688C2780059C9C4 /* SVGKParserPatternsAndGradients.h in Headers */,
-				66E864061688C2780059C9C4 /* SVGKParserSVG.h in Headers */,
-				66E864081688C2780059C9C4 /* SVGKParser.h in Headers */,
-				66E8640A1688C2780059C9C4 /* SVGKParseResult.h in Headers */,
-				66E8640C1688C2780059C9C4 /* SVGKParserExtension.h in Headers */,
-				66E8640D1688C2780059C9C4 /* SVGKPointsAndPathsParser.h in Headers */,
-				66E8640F1688C2780059C9C4 /* CALayerWithChildHitTest.h in Headers */,
-				66E864111688C2780059C9C4 /* CAShapeLayerWithHitTest.h in Headers */,
-				663403A4188EFC8A0077005F /* CALayer+RecursiveClone.h in Headers */,
-				582A6AF8283AEBA20057FEAF /* SVGKit-iOS-Prefix.pch in Headers */,
-				322A5B7D218BF990003D9CF1 /* SVGKInlineResource.h in Headers */,
-				66E864131688C2780059C9C4 /* CGPathAdditions.h in Headers */,
-				66E864151688C2780059C9C4 /* SVGKLayer.h in Headers */,
-				66E864171688C2780059C9C4 /* SVGKImage.h in Headers */,
-				66E864191688C2780059C9C4 /* SVGKit.h in Headers */,
-				66E8641A1688C2780059C9C4 /* SVGKSource.h in Headers */,
-				66E8641C1688C2780059C9C4 /* SVGKFastImageView.h in Headers */,
-				66E8641E1688C2780059C9C4 /* SVGKImageView.h in Headers */,
-				66E864201688C2780059C9C4 /* SVGKLayeredImageView.h in Headers */,
-				66E864241688C2780059C9C4 /* SVGKPattern.h in Headers */,
-				66E864261688C2780059C9C4 /* SVGUtils.h in Headers */,
-				66EEE8521688CA8A002E2658 /* SVGKParserGradient.h in Headers */,
-				66EEE8571688CA94002E2658 /* SVGKParserStyles.h in Headers */,
-				66EEE8601688CB37002E2658 /* SVGGradientElement.h in Headers */,
-				66EEE8621688CB37002E2658 /* SVGGradientStop.h in Headers */,
-				66EEE8641688CB37002E2658 /* SVGStyleCatcher.h in Headers */,
-				66EEE8651688CB37002E2658 /* SVGStyleElement.h in Headers */,
-				66372EF01695F193008C6C56 /* SVGStylable.h in Headers */,
-				6668E2081688D3CF00F774A6 /* SVGGElement.h in Headers */,
-				66988DB3168A001400EC93C7 /* CSSStyleDeclaration.h in Headers */,
-				66988DB7168A004D00EC93C7 /* CSSValue.h in Headers */,
-				66988DBB168A027E00EC93C7 /* CSSRule.h in Headers */,
-				668418C018674A0300C61EC2 /* SVGKExporterNSData.h in Headers */,
-				66988DBF168A031200EC93C7 /* CSSStyleSheet.h in Headers */,
-				66988DC3168A038400EC93C7 /* CSSRuleList.h in Headers */,
-				66988DC7168A04D100EC93C7 /* CSSRuleList+Mutable.h in Headers */,
-				66988DCB168A0A2300EC93C7 /* CSSPrimitiveValue.h in Headers */,
-				66988DCF168A129500EC93C7 /* CSSValueList.h in Headers */,
-				32D3D5DA2176E00E00ED20D8 /* SVGLinearGradientElement.h in Headers */,
-				66988DD3168A13BD00EC93C7 /* CSSValue_ForSubclasses.h in Headers */,
-				666674BA168A511400486B68 /* CSSStyleRule.h in Headers */,
-				666674C1168A556300486B68 /* StyleSheetList.h in Headers */,
-				666674C5168A55AF00486B68 /* StyleSheet.h in Headers */,
-				666674C9168A561C00486B68 /* MediaList.h in Headers */,
-				6694BB7B16967407007D0947 /* DOMGlobalSettings.h in Headers */,
-				663FD01416CAEF0D00CCBFB3 /* SVGHelperUtilities.h in Headers */,
-				663FD01B16CBEF5E00CCBFB3 /* BaseClassForAllSVGBasicShapes_ForSubclasses.h in Headers */,
-				661ADBF216CC2FBE006F4BC3 /* SVGTextPositioningElement.h in Headers */,
-				661ADBF716CC2FCA006F4BC3 /* SVGTextContentElement.h in Headers */,
-				661ADBFC16CC364F006F4BC3 /* SVGTextPositioningElement_Mutable.h in Headers */,
-				661AE44916D13DA8005E69D9 /* SVGTransformable.h in Headers */,
-				661AE44A16D13DAD005E69D9 /* SVGFitToViewBox.h in Headers */,
-				036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in Headers */,
-				6636CD8D175F54970072AAEF /* ConverterSVGToCALayer.h in Headers */,
-				66F33DD0182FE1C4004464AC /* SVGPreserveAspectRatio.h in Headers */,
-				66F33DD4182FE2C3004464AC /* SVGAnimatedPreserveAspectRatio.h in Headers */,
-				9ED79A24179D87790048AA5B /* SVGGradientLayer.h in Headers */,
-				BD2F8C51199D0897008AE06D /* SVGClipPathElement.h in Headers */,
-				BD4C56DC199D55CC00AF04AD /* CAShapeLayerWithClipRender.h in Headers */,
-				BDA133B719AD0E81003C9945 /* TinySVGTextAreaElement.h in Headers */,
-				BD2F8C55199D14D6008AE06D /* CALayerWithClipRender.h in Headers */,
-				6694B5DD199C10400028CFF6 /* SVGKSourceNSData.h in Headers */,
-				BD1585731996B13F00461AA5 /* NSData+NSInputStream.h in Headers */,
-				4FD821F01AC69F6600E419D3 /* SVGSwitchElement.h in Headers */,
-				BD0AFF8C19AE442F0001578E /* SVGUnitTypes.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		825CDAAC1BDA4BC0003C1C12 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2589,7 +2587,7 @@
 				6639618A16145D0400E58CCA /* Sources */,
 				6639618B16145D0400E58CCA /* Frameworks */,
 				6639618C16145D0400E58CCA /* CopyFiles */,
-				6639624616145D3E00E58CCA /* Headers */,
+				58F90EB5294189040074192B /* CopyFiles */,
 				582A6AF9283AEC090057FEAF /* ShellScript */,
 			);
 			buildRules = (


### PR DESCRIPTION
Turns out we can't create app archives with the current SVGKit changes.  Only generic archives.  Turns out it's this issue:

https://developer.apple.com/documentation/technotes/tn3110-resolving-generic-xcode-archive-issue

We need to use a Copy Files phase instead of a Headers phase. 