### PR TITLE
MRC-2476 polylines are not always parsed correctly

### DIFF
--- a/Source/Utils/SVGUtils.m
+++ b/Source/Utils/SVGUtils.m
@@ -484,54 +484,56 @@ CGFloat SVGPercentageFromString (const char *string) {
 }
 
 CGMutablePathRef createPathFromPointsInString (const char *string, boolean_t close) {
-	CGMutablePathRef path = CGPathCreateMutable();
-	
-	size_t len = strlen(string);
-	
-	char accum[MAX_ACCUM];
-	bzero(accum, MAX_ACCUM);
-	
-	int accumIdx = 0, currComponent = 0;
-	
-	for (size_t n = 0; n <= len; n++) {
-		char c = string[n];
-		
-		if (c == '\n' || c == '\t' || c == ' ' || c == ',' || c == '\0') {
-			accum[accumIdx] = '\0';
-			
-			static float x, y;
-			
-			if (currComponent == 0 && accumIdx != 0) {
-				sscanf( accum, "%g", &x );
-				currComponent++;
-			}
-			else if (currComponent == 1) {
-				
-				sscanf( accum, "%g", &y );
-				
-				if (CGPathIsEmpty(path)) {
-					CGPathMoveToPoint(path, NULL, x, y);
-				}
-				else {
-					CGPathAddLineToPoint(path, NULL, x, y);
-				}
-				
-				currComponent = 0;
-			}
-			
-			bzero(accum, MAX_ACCUM);
-			accumIdx = 0;
-		}
-		else if (isdigit(c) || c == '-' || c == '.') { // is digit or decimal separator OR A MINUS SIGN!!! ?
-			accum[accumIdx++] = c;
-		}
-	}
-	
-	if (close) {
-		CGPathCloseSubpath(path);
-	}
-	
-	return path;
+    CGMutablePathRef path = CGPathCreateMutable();
+    const char *progressPtr = string;
+    bool xScanned = false;
+    bool commaScanned = false;
+    float x = 0.0;
+    
+    while (*progressPtr) {
+        if (isspace(*progressPtr)) {
+            progressPtr++;
+            continue;
+        }
+        
+        // If we've already scanned x there may or may not be a single comma
+        if (xScanned && !commaScanned && *progressPtr == ',') {
+            progressPtr++;
+            commaScanned = true;
+            continue;
+        }
+        
+        // Attempt to scan a float coordinate value
+        errno = 0;
+        const char *floatPtr = progressPtr;
+        float nextCoordinate = strtof(floatPtr, (char**)&progressPtr);
+        if (errno != 0 || floatPtr == progressPtr) {
+            SVGKitLogError(@"Unable to parse float from path: \"%s\" errno: %d", string, errno);
+            return path;
+        }
+        
+        // If we have a coordinate pair update the path, otherwise continue scanning
+        if (xScanned) {
+            if (CGPathIsEmpty(path)) {
+                CGPathMoveToPoint(path, NULL, x, nextCoordinate);
+            }
+            else {
+                CGPathAddLineToPoint(path, NULL, x, nextCoordinate);
+            }
+            xScanned = false;
+            commaScanned = false;
+        }
+        else {
+            x = nextCoordinate;
+            xScanned = true;
+        }
+    }
+    
+    if (close) {
+        CGPathCloseSubpath(path);
+    }
+    
+    return path;
 }
 
 CGColorRef CGColorWithSVGColor (SVGColor color) {

--- a/Source/Utils/SVGUtils.m
+++ b/Source/Utils/SVGUtils.m
@@ -486,8 +486,8 @@ CGFloat SVGPercentageFromString (const char *string) {
 CGMutablePathRef createPathFromPointsInString (const char *string, boolean_t close) {
     CGMutablePathRef path = CGPathCreateMutable();
     const char *progressPtr = string;
-    bool xScanned = false;
-    bool commaScanned = false;
+    boolean_t xScanned = false;
+    boolean_t commaScanned = false;
     float x = 0.0;
     
     while (*progressPtr) {


### PR DESCRIPTION
https://meridianapps.atlassian.net/browse/MRC-2476

`ployline` is a `lineto` command:
https://www.w3.org/TR/SVG2/paths.html#PathDataBNF

IMO this new implementation handles that much more clearly and thoroughly that the previous one.   (Though I'll have to do a good writeup about it to PR this into the upstream library since it's a complete rewrite of the function)