### PR TITLE
Only create often-used NSCharacterSets a single time

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGElement.m
@@ -22,6 +22,8 @@
 
 #import "SVGKDefine_Private.h"
 
+#import "NSCharacterSet+SVGKExtensions.h"
+
 @interface SVGElement ()
 
 @property (nonatomic, copy) NSString *stringValue;
@@ -450,8 +452,7 @@
 
 - (NSRange) nextSelectorRangeFromText:(NSString *) selectorText startFrom:(NSRange) previous
 {
-    NSMutableCharacterSet *identifier = [NSMutableCharacterSet alphanumericCharacterSet];
-    [identifier addCharactersInString:@"-_"];
+    NSCharacterSet *identifier = [NSCharacterSet SVGAlphanumericAndDashesCharacterSet];
 	NSCharacterSet *selectorStart = [NSCharacterSet characterSetWithCharactersInString:@"#."];
     
     NSInteger start = -1;
@@ -491,10 +492,9 @@
         if( element.className != nil )
         {
             NSScanner *classNameScanner = [NSScanner scannerWithString:element.className];
-            NSMutableCharacterSet *whitespaceAndCommaSet = [NSMutableCharacterSet whitespaceCharacterSet];
+            NSCharacterSet *whitespaceAndCommaSet = [NSCharacterSet SVGWhitespaceAndCommaCharacterSet];
             NSString *substring;
             
-            [whitespaceAndCommaSet addCharactersInString:@","];
             selector = [selector substringFromIndex:1];
             __block BOOL matched = NO;
 

--- a/Source/Foundation additions/NSCharacterSet+SVGKExtensions.h
+++ b/Source/Foundation additions/NSCharacterSet+SVGKExtensions.h
@@ -11,5 +11,7 @@
 @interface NSCharacterSet (SVGKExtensions)
 
 + (NSCharacterSet *)SVGWhitespaceCharacterSet;
++ (NSCharacterSet *)SVGWhitespaceAndCommaCharacterSet;
++ (NSCharacterSet *)SVGAlphanumericAndDashesCharacterSet;
 
 @end

--- a/Source/Foundation additions/NSCharacterSet+SVGKExtensions.m
+++ b/Source/Foundation additions/NSCharacterSet+SVGKExtensions.m
@@ -15,8 +15,7 @@
  wsp:
  (#x20 | #x9 | #xD | #xA)
  */
-+ (NSCharacterSet *)SVGWhitespaceCharacterSet;
-{
++ (NSCharacterSet *)SVGWhitespaceCharacterSet {
 	static NSCharacterSet *sWhitespaceCharacterSet = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -28,4 +27,34 @@
     return sWhitespaceCharacterSet;
 }
 
+/**
+ Returns Apple's whitespace character set with an added comma.
+ It's expensive to both create and modify NSCharacterSet, so we ensure it is only done once since this set is used frequently.
+ */
+
++ (NSCharacterSet *)SVGWhitespaceAndCommaCharacterSet {
+    static NSCharacterSet *sWhitespaceAndCommaCharacterSet = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableCharacterSet *whitespaceSet = [NSMutableCharacterSet whitespaceCharacterSet];
+        [whitespaceSet addCharactersInString:@","];
+        sWhitespaceAndCommaCharacterSet = whitespaceSet;
+    });
+    return sWhitespaceAndCommaCharacterSet;
+}
+
+/**
+ Returns Apple's alphanumeric character set with an added dash and underscore.
+ It's expensive to both create and modify NSCharacterSet, so we ensure it is only done once since this set is used frequently.
+ */
++ (NSCharacterSet *)SVGAlphanumericAndDashesCharacterSet {
+    static NSCharacterSet *sAlphanumericAndDashesCharacterSet = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableCharacterSet *alphanumerics = [NSMutableCharacterSet alphanumericCharacterSet];
+        [alphanumerics addCharactersInString:@"-_"];
+        sAlphanumericAndDashesCharacterSet = alphanumerics;
+    });
+    return sAlphanumericAndDashesCharacterSet;
+}
 @end


### PR DESCRIPTION
https://meridianapps.atlassian.net/browse/MRC-2905

Creating and modifying NSMutableCharacterSet is a relatively expensive operation, in the debugger you can see that every modification to it resorts in a call to qsort (which makes sense, since a sorted character array would perform much better for lookups etc).   These two NSMutableCharacterSets are created and modified in a function that is called recursively many, many, many times when parsing an SVG file.

One of our customers has a map with over a 1000 layers and this change takes the load time of that map from ~12 seconds, to under 2 seconds.