### PR TITLE
MRC-3043 explicitly handle coordinate_sequence commas

### DIFF
--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -691,6 +691,7 @@ static inline CGPoint SVGCurveReflectedControlPoint(SVGCurve prevCurve)
     CGPathAddLineToPoint(path, NULL, coord.x, coord.y);
 
     while (![scanner isAtEnd]) {
+        [SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
         origin = isRelative ? coord : origin;
         [SVGKPointsAndPathsParser readCoordinate:scanner intoFloat:&yValue];
         vertCoord = CGPointMake(origin.x, origin.y+yValue);
@@ -745,6 +746,7 @@ static inline CGPoint SVGCurveReflectedControlPoint(SVGCurve prevCurve)
     CGPathAddLineToPoint(path, NULL, coord.x, coord.y);
 
     while (![scanner isAtEnd]) {
+        [SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
         origin = isRelative ? coord : origin;
         [SVGKPointsAndPathsParser readCoordinate:scanner intoFloat:&xValue];
         horizCoord = CGPointMake(origin.x+xValue, origin.y);


### PR DESCRIPTION
https://meridianapps.atlassian.net/browse/MRC-3043

Per [Section 9.3.9 of the SVG Spec](https://www.w3.org/TR/SVG2/paths.html#PathDataBNF):
Horizontal and Vertical lineto paths are followed by a `coordinate_sequence` which is essentially a list of numbers separated by either whitespace or a comma.  This library currently supports just whitespace.  

I expect the reason we haven't ran into this before is that, even though it's supported, it doesn't make all that much sense to include more than a single destination coordinate for horizontal or vertical lineto paths. 